### PR TITLE
Do not lock the gtk4 shard version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -3,13 +3,13 @@ description: libadwaita bindings for Crystal
 version: 1.0.0
 
 authors:
-  - Hugo Parente Lima <hugo.pl@gmail.com>
   - Evangelos "GeopJr" Paterakis <evan@geopjr.dev>
+  - Hugo Parente Lima <hugo.pl@gmail.com>
 
 dependencies:
   gtk4:
     github: hugopl/gtk4.cr
-    version: "~> 0.14.0"
+    version: ">= 0.14.0"
 
 crystal: ">= 1.0.0"
 


### PR DESCRIPTION
Hi,

It's better to specify just the minimum version required for it to work, so people can use newer versions of GTK4 shard without need to wait for a release on this shard.

I also re-arranged the authors list if you don't mind.
